### PR TITLE
feat: Basic Notification Service Implementation

### DIFF
--- a/docker/apps.yml
+++ b/docker/apps.yml
@@ -85,6 +85,41 @@ services:
     networks:
       - carhunters_network
 
+  notification-service:
+    image: dawid0604/carhunters-notification-service
+    container_name: notification-service
+    environment:
+      - CONFIG_SERVICE_INSTANCE=config-service
+      - DISCOVERY_SERVICE_INSTANCE=discovery-service
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_HOST=notification-mongo-db
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_USER=${NOTIFICATION_MICROSERVICE_MONGO_DB_USER}
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_PASSWORD=${NOTIFICATION_MICROSERVICE_MONGO_DB_PASSWORD}
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_PORT=${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT}
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_DATABASE=${NOTIFICATION_MICROSERVICE_MONGO_DB_DATABASE}
+      - NOTIFICATION_MICROSERVICE_MONGO_DB_AUTHENTICATION_DATABASE=${NOTIFICATION_MICROSERVICE_MONGO_DB_AUTHENTICATION_DATABASE}
+      - KAFKA_SERVER=kafka
+
+    restart: unless-stopped
+    depends_on:
+      discovery-service:
+        condition: service_healthy
+
+      config-service:
+        condition: service_healthy
+
+      kafka:
+        condition: service_healthy
+
+    deploy:
+      resources:
+        limits:
+          memory: 700M
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
 networks:
   carhunters_network:
     driver: bridge

--- a/docker/dashboards.yml
+++ b/docker/dashboards.yml
@@ -1,0 +1,84 @@
+name: "Dashboards"
+
+services:
+  user-service-pgadmin:
+    build: resources/pgadmin
+    container_name: user-service-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${USER_MICROSERVICE_PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${USER_MICROSERVICE_PGADMIN_PASSWORD}
+      SERVER_NAME: user-service-db-server
+      DATABASE_HOST: user-service-postgres-db
+      DATABASE_PORT: ${USER_MICROSERVICE_POSTGRES_PORT}
+      DATABASE_NAME: ${USER_MICROSERVICE_POSTGRES_DB}
+      DATABASE_USER: ${USER_MICROSERVICE_POSTGRES_USER}
+      DATABASE_PASSWORD: ${USER_MICROSERVICE_POSTGRES_PASSWORD}
+
+    ports:
+      - "5050:80"
+
+    depends_on:
+      user-service-postgres-db:
+        condition: service_healthy
+
+    networks:
+      - carhunters_network
+
+  notification-service-mongo-db-express:
+    image: mongo-express:1.0.2-20-alpine3.19
+    container_name: notification-db-express
+    restart: unless-stopped
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://${NOTIFICATION_MICROSERVICE_MONGO_DB_USER}:${NOTIFICATION_MICROSERVICE_MONGO_DB_PASSWORD}@notification-mongo-db:${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT}/${NOTIFICATION_MICROSERVICE_MONGO_DB_AUTHENTICATION_DATABASE}?authSource=admin
+      ME_CONFIG_BASICAUTH_USERNAME: ${NOTIFICATION_MICROSERVICE_MONGO_EXPRESS_USER}
+      ME_CONFIG_BASICAUTH_PASSWORD: ${NOTIFICATION_MICROSERVICE_MONGO_EXPRESS_PASSWORD}
+
+    ports:
+      - "48081:8081"
+
+    depends_on:
+      notification-mongo-db:
+        condition: service_healthy
+
+    deploy:
+      resources:
+        limits:
+          memory: 700M
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:v0.7.2
+    container_name: kafka-ui
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+
+    ports:
+      - "48083:8080"
+
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+
+      kafka:
+        condition: service_healthy
+
+    deploy:
+      resources:
+        limits:
+          memory: 700M
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
+networks:
+  carhunters_network:
+    driver: bridge
+    name: carhunters_network

--- a/docker/infra.yml
+++ b/docker/infra.yml
@@ -2,6 +2,7 @@ name: "Infrastructure"
 
 volumes:
   user-service-postgres-volume:
+  notification-mongo-db-volume:
 
 services:
   user-service-postgres-db:
@@ -29,6 +30,96 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
+  notification-mongo-db:
+    image: mongo:8.0.9
+    container_name: notification-mongo-db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${NOTIFICATION_MICROSERVICE_MONGO_DB_USER}
+      - MONGO_INITDB_ROOT_PASSWORD=${NOTIFICATION_MICROSERVICE_MONGO_DB_PASSWORD}
+      - MONGO_INITDB_DATABASE=${NOTIFICATION_MICROSERVICE_MONGO_DB_DATABASE}
+
+    healthcheck:
+      test: [ "CMD-SHELL", "echo 'db.runCommand(\"ping\").ok' | mongosh localhost:${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT:-27017}/test --quiet" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+    volumes:
+      - notification-mongo-db-volume:/data/db
+
+    ports:
+      - "${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT}:${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT}"
+
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
+  zookeeper:
+    image: zookeeper:3.9.3-jre-17
+    container_name: zookeeper
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "2181" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+    ports:
+      - "22181:2181"
+
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+
+        reservations:
+          memory: 256M
+
+    networks:
+      - carhunters_network
+
+  kafka:
+    image: confluentinc/cp-kafka:7.9.1
+    container_name: kafka
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "9092" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+    ports:
+      - "9092:29092"
+
+    environment:
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://host.docker.internal:9092
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
 
     deploy:
       resources:

--- a/docker/resources/pgadmin/Dockerfile
+++ b/docker/resources/pgadmin/Dockerfile
@@ -1,0 +1,7 @@
+FROM dpage/pgadmin4:9.4.0
+USER root
+
+COPY generate-server.sh /generate-server-json.sh
+RUN chmod +x /generate-server-json.sh
+
+ENTRYPOINT [ "/generate-server-json.sh" ]

--- a/docker/resources/pgadmin/generate-server.sh
+++ b/docker/resources/pgadmin/generate-server.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cat <<EOF > /pgadmin4/servers.json
+{
+  "Servers": {
+    "1": {
+      "Name": "${SERVER_NAME}",
+      "Group": "Servers",
+      "Host": "${DATABASE_HOST}",
+      "Port": ${DATABASE_PORT},
+      "MaintenanceDB": "${DATABASE_NAME}",
+      "Username": "${DATABASE_USER}",
+      "Password": "${DATABASE_PASSWORD}",
+      "SSLMode": "prefer"
+    }
+  }
+}
+EOF
+
+exec /entrypoint.sh

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<module>services/config-service</module>
 		<module>services/discovery-service</module>
 		<module>services/user-service</module>
+		<module>services/notification-service</module>
 	</modules>
 
 	<reporting>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -49,5 +49,11 @@
             <artifactId>carhunters-user-service</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>pl.dawid0604</groupId>
+            <artifactId>carhunters-notification-service</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/services/config-service/src/main/resources/configurations/notification-service.yml
+++ b/services/config-service/src/main/resources/configurations/notification-service.yml
@@ -1,0 +1,37 @@
+spring:
+  data:
+    mongodb:
+      username: ${NOTIFICATION_MICROSERVICE_MONGO_DB_USER}
+      password: ${NOTIFICATION_MICROSERVICE_MONGO_DB_PASSWORD}
+      host: ${NOTIFICATION_MICROSERVICE_MONGO_DB_HOST:localhost}
+      port: ${NOTIFICATION_MICROSERVICE_MONGO_DB_PORT}
+      database: ${NOTIFICATION_MICROSERVICE_MONGO_DB_DATABASE}
+      authentication-database: ${NOTIFICATION_MICROSERVICE_MONGO_DB_AUTHENTICATION_DATABASE}
+
+      connection-pool:
+        max-size: 10
+        min-size: 2
+        max-connection-idle-time: 60000
+        max-connection-life-time: 1800000
+        max-wait-time: 30000
+
+      option:
+        ssl: false
+        max-connecting: 20
+        heartbeat-frequency: 10000
+        server-selection-timeout: 30000
+
+  kafka:
+    consumer:
+      bootstrap-servers: ${KAFKA_SERVER}
+      group-id: notification-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+#        spring.json.trusted.packages: '*'
+        spring.kafka.consumer.enable-aut-commit: false
+        spring.kafka.listener.ack-mode: MANUAL_IMMEDIATE
+
+server:
+  port: 0

--- a/services/notification-service/README.md
+++ b/services/notification-service/README.md
@@ -1,0 +1,1 @@
+# Notification service

--- a/services/notification-service/pom.xml
+++ b/services/notification-service/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<parent>
+		<groupId>pl.dawid0604</groupId>
+		<artifactId>carhunters-root</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>carhunters-notification-service</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>CarHunters - Notification Service</name>
+
+	<properties>
+		<mainClass>pl.dawid0604.carhunters.notification.service.CarHuntersNotificationServiceApplication</mainClass>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.1.8</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>**/CarHuntersNotificationServiceApplication.class</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+
+		</plugins>
+	</build>
+</project>

--- a/services/notification-service/src/main/java/pl/dawid0604/carhunters/notification/service/CarHuntersNotificationServiceApplication.java
+++ b/services/notification-service/src/main/java/pl/dawid0604/carhunters/notification/service/CarHuntersNotificationServiceApplication.java
@@ -1,0 +1,22 @@
+package pl.dawid0604.carhunters.notification.service;
+
+import lombok.NoArgsConstructor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@EnableCaching
+@SpringBootApplication
+@EnableDiscoveryClient
+@SuppressWarnings("PMD")
+@NoArgsConstructor(access = PACKAGE)
+class CarHuntersNotificationServiceApplication {
+
+	public static void main(final String[] args) {
+		SpringApplication.run(CarHuntersNotificationServiceApplication.class, args);
+	}
+
+}

--- a/services/notification-service/src/main/java/pl/dawid0604/carhunters/notification/service/config/AuditingConfig.java
+++ b/services/notification-service/src/main/java/pl/dawid0604/carhunters/notification/service/config/AuditingConfig.java
@@ -1,0 +1,23 @@
+package pl.dawid0604.carhunters.notification.service.config;
+
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+import java.util.Optional;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@SuppressWarnings("unused")
+@Configuration
+@EnableMongoAuditing
+@NoArgsConstructor(access = PACKAGE)
+class AuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return Optional::empty;
+    }
+}

--- a/services/notification-service/src/main/resources/application.yml
+++ b/services/notification-service/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: notification-service
+
+  config:
+    import: configserver:http://${CONFIG_SERVICE_INSTANCE:localhost}:8888

--- a/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/CarHuntersNotificationServiceApplicationTests.java
+++ b/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/CarHuntersNotificationServiceApplicationTests.java
@@ -1,0 +1,17 @@
+package pl.dawid0604.carhunters.notification.service;
+
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import static lombok.AccessLevel.PACKAGE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@NoArgsConstructor(access = PACKAGE)
+class CarHuntersNotificationServiceApplicationTests extends IntegrationTestBase {
+
+	@Test
+	void contextLoads() {
+		assertTrue(true);
+	}
+
+}

--- a/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/IntegrationTestBase.java
+++ b/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/IntegrationTestBase.java
@@ -1,0 +1,38 @@
+package pl.dawid0604.carhunters.notification.service;
+
+import lombok.NoArgsConstructor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.kafka.KafkaContainer;
+
+import static lombok.AccessLevel.PACKAGE;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static pl.dawid0604.carhunters.notification.service.IntegrationTestBase.ContainersConfig;
+
+@Import(ContainersConfig.class)
+@NoArgsConstructor(access = PACKAGE)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public abstract class IntegrationTestBase {
+
+    @TestConfiguration
+    static class ContainersConfig {
+
+        @Bean
+        @ServiceConnection
+        @SuppressWarnings("unused")
+        MongoDBContainer mongoDBContainer() {
+            return new MongoDBContainer("mongo:8.0.9");
+        }
+
+        @Bean
+        @ServiceConnection
+        @SuppressWarnings("unused")
+        KafkaContainer kafkaContainer() {
+            return new KafkaContainer("apache/kafka:3.9.1");
+        }
+    }
+}

--- a/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/config/AuditingConfigTest.java
+++ b/services/notification-service/src/test/java/pl/dawid0604/carhunters/notification/service/config/AuditingConfigTest.java
@@ -1,0 +1,36 @@
+package pl.dawid0604.carhunters.notification.service.config;
+
+import lombok.NoArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@NoArgsConstructor(access = PACKAGE)
+class AuditingConfigTest {
+
+    @Spy
+    private final AuditingConfig auditingConfig = new AuditingConfig();
+
+    @Nested
+    @DisplayName("Success")
+    @NoArgsConstructor(access = PACKAGE)
+    class Success {
+
+        @Test
+        void shouldReturnEmptyAuditor() {
+            // Given
+            // When
+            // Then
+            Assertions.assertThat(auditingConfig.auditorAware())
+                      .extracting(AuditorAware::getCurrentAuditor)
+                      .matches(Optional::isEmpty);
+        }
+    }
+}

--- a/services/notification-service/src/test/resources/application.yml
+++ b/services/notification-service/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: notification-service
+
+  output:
+    ansi:
+      enabled: ALWAYS
+
+  config:
+    import: optional:configserver:http://${CONFIG_SERVICE_INSTANCE:localhost}:8888


### PR DESCRIPTION
## 🧾 Description 

The service starts up successfully, exposes /health and /actuator endpoints and the configuration is fetched from the Config Service.

Done things:
- The Service connects with MongoDB
- The TestContainers is properly configured
- The Service added to apps.yml
- The Mongo Auditing is enabled
- The Service connects with Kafka
- The file infra.yml includes required dependencies
- The file apps.yml include Notification Service
- The file dashboards.yml includes KafkaUI and MongoExpress
- Missing User Service PgAdmin was added with ability to generating servers

## 🧩 Type of changes 

- [x] New functionality ✨
- [ ] Bug fixes 🐛
- [ ] Refactoring 🔨
- [ ] Tests ✅
- [ ] Others (describe):

## 📌 References 

Closes #5